### PR TITLE
Fixed bug with new lines-of-code summary

### DIFF
--- a/src/main/java/hudson/plugins/cppncss/parser/FormattedStatisticSummary.java
+++ b/src/main/java/hudson/plugins/cppncss/parser/FormattedStatisticSummary.java
@@ -88,7 +88,7 @@ public final class FormattedStatisticSummary extends StatisticSummary {
         return "<ul>"
                 + diff(wasCcn, ccn, "ccn")
                 + diff(wasFunctions, functions, "functions")
-                + diff(wasCcn, ncss, "ncss")
+                + diff(wasNcss, ncss, "ncss")
                 + "</ul>";
     }
 

--- a/src/test/java/hudson/plugins/cppncss/parser/FormattedStatisticSummaryTest.java
+++ b/src/test/java/hudson/plugins/cppncss/parser/FormattedStatisticSummaryTest.java
@@ -1,0 +1,15 @@
+package hudson.plugins.cppncss.parser;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class FormattedStatisticSummaryTest {
+
+	@Test
+	public void getHtmlSummaryReportsCorrectDifferences() {
+		FormattedStatisticSummary fss = new FormattedStatisticSummary(10, 11, 12, 7, 6, 14);
+		assertEquals(fss.getHtmlSummary(), "<ul><li>ccn (-3)</li><li>functions (-5)</li><li>ncss (+2)</li></ul>");
+	}
+
+}


### PR DESCRIPTION
Used to show current loc minus previous ccn, now shows current loc minus previous loc.